### PR TITLE
feat: add 5000ms timeout on meta

### DIFF
--- a/pages/api/getVaults.tsx
+++ b/pages/api/getVaults.tsx
@@ -228,7 +228,7 @@ export async function getVaults(
 	**************************************************************************/
 	const	[_vaultsInitialsRaw, _strategiesRaw, _graphRaw, _blockNumberRaw] = await Promise.allSettled([
 		axios.get(`https://api.yearn.finance/v1/chains/${chainID || 1}/vaults/all`),
-		axios.get(`https://meta.yearn.network/strategies/${chainID || 1}/all`),
+		axios.get(`https://meta.yearn.network/strategies/${chainID || 1}/all`, {timeout: 5000}),
 		request(graphProvider, GRAPH_REQUEST),
 		rpcProvider.getBlockNumber()
 	]);


### PR DESCRIPTION
Add a timeout of 5s to the meta.yearn.network fetch to avoid the getVault function to wait forever when Meta is slow/down or else