### PR TITLE
feat: use new meta uri

### DIFF
--- a/components/sections/alerts/SectionAlertList.tsx
+++ b/components/sections/alerts/SectionAlertList.tsx
@@ -218,7 +218,7 @@ const	SectionAlertList = React.memo(function SectionAlertList({stratOrVault, sho
 				<Card.Detail
 					key={stratOrVault.address}
 					isSticky={false}
-					summary={(p: unknown): ReactElement => (
+					summary={(p: unknown[]): ReactElement => (
 						<Card.Detail.Summary
 							startChildren={renderSummaryStart(stratOrVault)}
 							endChildren={renderSummaryEnd(stratOrVault)}

--- a/components/sections/strategies/SectionReports.tsx
+++ b/components/sections/strategies/SectionReports.tsx
@@ -47,7 +47,7 @@ const	SectionReports = React.memo(function SectionReports({currentVault, current
 								key={report.id}
 								variant={'background'}
 								isSticky={false}
-								summary={(p: unknown): ReactElement => (
+								summary={(p: unknown[]): ReactElement => (
 									<Card.Detail.Summary
 										startChildren={(
 											<div>

--- a/components/sections/vaults/VaultBox.tsx
+++ b/components/sections/vaults/VaultBox.tsx
@@ -108,7 +108,7 @@ const VaultBox = React.memo(function VaultBox({vault, isOnlyInQueue = false}: TV
 
 	return (
 		<Card.Detail
-			summary={(p: unknown): ReactElement => (
+			summary={(p: unknown[]): ReactElement => (
 				<Card.Detail.Summary
 					startChildren={renderSummaryStart()}
 					endChildren={renderSummaryEnd()}

--- a/pages/api/getVaults.tsx
+++ b/pages/api/getVaults.tsx
@@ -228,7 +228,7 @@ export async function getVaults(
 	**************************************************************************/
 	const	[_vaultsInitialsRaw, _strategiesRaw, _graphRaw, _blockNumberRaw] = await Promise.allSettled([
 		axios.get(`https://api.yearn.finance/v1/chains/${chainID || 1}/vaults/all`),
-		axios.get(`https://meta.yearn.network/strategies/${chainID || 1}/all`, {timeout: 5000}),
+		axios.get(`https://meta.yearn.finance/api/strategies/${chainID || 1}/all`, {timeout: 5000}),
 		request(graphProvider, GRAPH_REQUEST),
 		rpcProvider.getBlockNumber()
 	]);


### PR DESCRIPTION
- Update the baseURI for the meta endpoint, from `meta.yearn.network` to `meta.yearn.finance`
- Fix some linting issues