### PR TITLE
Change the source of risk framework json to the API endpoint

### DIFF
--- a/pages/risk.tsx
+++ b/pages/risk.tsx
@@ -70,7 +70,7 @@ function	Risk(): ReactElement {
 		let		_totalDebt = 0;
 
 		async function fetchRiskGroups(): Promise<void> {
-			const endpoint = 'http://yearn-data-dev.us-west-2.elasticbeanstalk.com/api/riskgroups';
+			const endpoint = 'http://yearn-data-analytics.us-west-2.elasticbeanstalk.com/api/riskgroups';
 			const response = await axios.get(endpoint);
 			if (response.status === 200) {
 				const riskGroups = response.data as TRiskGroup[];


### PR DESCRIPTION
Related to Issue #23

The PR should enable the app to fetch the risk framework file from the API endpoint.
The screenshots below show that the numbers tally.

## Screenshots

![image](https://user-images.githubusercontent.com/30872891/172021849-fbd27d88-50c5-4287-a9b0-949538a46315.png)

The 3 errors shown in the above screenshot are about the hydration in Next js, which I believe is a local issue and thus would not occur in the server.

![image](https://user-images.githubusercontent.com/30872891/172021744-5133ff6d-e5e7-42a6-b2aa-addc76f95a2a.png)

![image](https://user-images.githubusercontent.com/30872891/172021772-0214db06-27d1-49e5-9562-b881ac6b58fc.png)


