### PR TITLE
add strategy name to strategies page

### DIFF
--- a/components/sections/strategies/SectionAbout.tsx
+++ b/components/sections/strategies/SectionAbout.tsx
@@ -21,6 +21,15 @@ const	SectionAbout = React.memo(function SectionAbout({currentVault, currentStra
 				</div>
 
 				<div className={'mb-8'}>
+					<b>{'Strategy Name'}</b>
+					<div className={'flex-row-center mt-4'}>
+						<p
+							className={'text-neutral-500'}
+						>{currentStrategy?.name}</p>
+					</div>
+				</div>
+
+				<div className={'mb-8'}>
 					<b>{'Description'}</b>
 					<div className={'flex-row-center mt-4'}>
 						<p


### PR DESCRIPTION
I was writing an article and I noticed the strategies names were missing on this page and I had to get them at the yearn-meta repo, so I thought it would be nice to show them here too so data is concentrated in 1 place for consumers :)