### PR TITLE
feat: Add support for multiple subgraph urls

### DIFF
--- a/components/StandardFooter.tsx
+++ b/components/StandardFooter.tsx
@@ -1,7 +1,7 @@
-import	React, {ReactElement}		from	'react';
-import	{SwitchTheme}				from	'@yearn-finance/web-lib/components';
-import	{useUI, useWeb3}						from	'@yearn-finance/web-lib/contexts';
-import	meta						from	'public/manifest.json';
+import React, {ReactElement} from 'react';
+import {SwitchTheme} from '@yearn-finance/web-lib/components';
+import {useUI, useWeb3} from '@yearn-finance/web-lib/contexts';
+import meta from 'public/manifest.json';
 
 const SUBGRAPH_URLS = new Map([
 	[1, 'https://api.thegraph.com/subgraphs/name/rareweasel/yearn-vaults-v2-subgraph-mainnet'],

--- a/components/StandardFooter.tsx
+++ b/components/StandardFooter.tsx
@@ -1,17 +1,27 @@
 import React, {ReactElement} from 'react';
 import {SwitchTheme} from '@yearn-finance/web-lib/components';
-import {useUI} from '@yearn-finance/web-lib/contexts';
+import {useUI, useWeb3} from '@yearn-finance/web-lib/contexts';
 import meta from 'public/manifest.json';
+
+const SUBGRAPH_URLS = new Map([
+	[1, ''],
+	[10, ''],
+	[250, ''],
+	[42161, ''],
+	[1337, ''],
+	[31337, '']
+]);
 
 function	Footer(): ReactElement {
 	const	{theme, switchTheme} = useUI();
+	const	{chainID} = useWeb3();
 
 	return (
 		<footer className={'mx-auto mt-auto hidden w-full max-w-6xl flex-row items-center py-8 md:flex'}>
 			<a href={meta.github} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>
 				{'Yearn.watch repo'}
 			</a>
-			<a href={'https://gov.yearn.finance/'} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>
+			<a href={SUBGRAPH_URLS.has(chainID) ? SUBGRAPH_URLS.get(chainID) : 'https://gov.yearn.finance/'} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>
 				{'Subgraph'}
 			</a>
 			<a href={'https://discord.yearn.finance/'} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>

--- a/components/StandardFooter.tsx
+++ b/components/StandardFooter.tsx
@@ -4,12 +4,10 @@ import {useUI, useWeb3} from '@yearn-finance/web-lib/contexts';
 import meta from 'public/manifest.json';
 
 const SUBGRAPH_URLS = new Map([
-	[1, ''],
-	[10, ''],
-	[250, ''],
-	[42161, ''],
-	[1337, ''],
-	[31337, '']
+	[1, 'https://api.thegraph.com/subgraphs/name/rareweasel/yearn-vaults-v2-subgraph-mainnet'],
+	[10, 'https://api.thegraph.com/subgraphs/name/yearn/yearn-vaults-v2-optimism'],
+	[250, 'https://api.thegraph.com/subgraphs/name/bsamuels453/yearn-fantom-validation-grafted'],
+	[42161, 'https://api.thegraph.com/subgraphs/name/yearn/yearn-vaults-v2-arbitrum']
 ]);
 
 function	Footer(): ReactElement {
@@ -21,9 +19,9 @@ function	Footer(): ReactElement {
 			<a href={meta.github} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>
 				{'Yearn.watch repo'}
 			</a>
-			<a href={SUBGRAPH_URLS.has(chainID) ? SUBGRAPH_URLS.get(chainID) : 'https://gov.yearn.finance/'} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>
+			{SUBGRAPH_URLS.has(chainID) && <a href={SUBGRAPH_URLS.get(chainID)} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>
 				{'Subgraph'}
-			</a>
+			</a>}
 			<a href={'https://discord.yearn.finance/'} target={'_blank'} className={'pr-6 text-xs text-neutral-500 transition-colors hover:text-accent-500 hover:underline'} rel={'noreferrer'}>
 				{'Discord'}
 			</a>

--- a/components/StandardFooter.tsx
+++ b/components/StandardFooter.tsx
@@ -1,7 +1,7 @@
-import React, {ReactElement} from 'react';
-import {SwitchTheme} from '@yearn-finance/web-lib/components';
-import {useUI, useWeb3} from '@yearn-finance/web-lib/contexts';
-import meta from 'public/manifest.json';
+import	React, {ReactElement}		from	'react';
+import	{SwitchTheme}				from	'@yearn-finance/web-lib/components';
+import	{useUI, useWeb3}						from	'@yearn-finance/web-lib/contexts';
+import	meta						from	'public/manifest.json';
 
 const SUBGRAPH_URLS = new Map([
 	[1, 'https://api.thegraph.com/subgraphs/name/rareweasel/yearn-vaults-v2-subgraph-mainnet'],


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Change the subgraph url in the footer depending on the chain selected

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn-watch/issues/116

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The Subgraph link should point to the currently selected network's active subgraph or the github repo we use to track it. It is pointing to gov.yearn.finance atm.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally
