### PR TITLE
feat: created allocations page according to the issue

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,7 @@ import	{Card, Dropdown, ModalMobileMenu}	from	'@yearn-finance/web-lib/components
 import	{NetworkEthereum, NetworkFantom,
 	NetworkArbitrum, Hamburger}				from	'@yearn-finance/web-lib/icons';
 
-const	options: any[] = [
+export const	options: any[] = [
 	{icon: <NetworkEthereum />, label: 'Ethereum', value: 1},
 	{icon: <NetworkFantom />, label: 'Fantom', value: 250},
 	{icon: <NetworkArbitrum />, label: 'Arbitrum', value: 42161}

--- a/components/sections/allocations/SectionAllocationsList.tsx
+++ b/components/sections/allocations/SectionAllocationsList.tsx
@@ -1,0 +1,144 @@
+import	React, {ReactElement}	    from	'react';
+import	{List}						from	'@yearn-finance/web-lib/layouts';
+import	{Card}						from	'@yearn-finance/web-lib/components';
+import	* as utils					from	'@yearn-finance/web-lib/utils';
+import	{Chevron}					from	'@yearn-finance/web-lib/icons';
+import {format} 					from 	'@yearn-finance/web-lib/utils';
+import {TChainData, TProtocolData}  from 	'../../../pages/allocations';
+
+const	ProtocolBox = React.memo(function ProtocolBox({protocol}: {protocol: TProtocolData}): ReactElement {
+
+	function	renderSummary(p: {open: boolean}): ReactElement {
+		return (
+			<div className={`rounded-default relative grid h-20 w-[965px] grid-cols-22 bg-neutral-0 py-4 px-6 transition-colors md:w-full ${p.open ? '' : 'hover:bg-neutral-100'}`}>
+				<div className={'min-w-32 col-span-5 flex flex-row items-center'}>
+					<div className={'text-neutral-500'}>
+						<div className={'flex-row-center'}>
+							<div>
+								<b>{protocol.name}</b>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div className={'min-w-36 cell-end col-span-4 mr-5 flex flex-row items-center tabular-nums'}>
+					<div>
+						<b>{`${utils.format.amount(protocol.tvl, 2)}$`}</b>
+						<p className={'text-sm'}>{`${utils.format.amount(protocol.totalDebtRatio, 2)}%`}</p>
+					</div>
+				</div>
+				<div className={'min-w-36 cell-end col-span-4 mr-5 flex flex-row items-center tabular-nums'}>
+					<div>
+						{protocol.strategiesAmount}
+					</div>
+				</div>
+				<div className={'min-w-36 cell-end col-span-5 flex flex-row items-center tabular-nums'}>
+					<div>
+						{protocol.allocatedStrategies}
+					</div>
+				</div>
+				<div className={'min-w-36 cell-end col-span-4 flex flex-row items-center'}>
+					<div className={'ml-2'}>
+						<Chevron
+							className={`h-6 w-6 text-accent-500 transition-transform ${p.open ? '-rotate-90' : '-rotate-180'}`} />
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	function	RenderDetail(): ReactElement {
+		const _strategiesList = Object.keys(protocol.strategiesTVL).map((strategy): {
+			name: string, tvl: number
+		} => {
+			return {
+				name: strategy,
+				tvl: protocol.strategiesTVL[strategy]
+			};
+		});
+		const strategiesList = _strategiesList.sort((a, b): number => {
+			return b.tvl - a.tvl;
+		});
+		return (
+			<div className={'my-10'}>
+				{
+					strategiesList.map((strategy): ReactElement => {
+						return (
+							<div className={'mb-10'} key={strategy.name}>
+								<div className={'mx-auto flex w-10/12 flex-col'}>
+									<span className={'mb-2 flex flex-row items-center justify-between'}>
+										<p className={'text-left text-neutral-500'}>{`${strategy.name}`}</p>
+										<b className={'text-left text-accent-500'}>
+											{`${format.amount(protocol.tvl ? strategy.tvl / protocol.tvl * 100 : 0)}%`}
+										</b>
+									</span>
+									<div>
+										<div className={'relative h-2 w-full overflow-hidden rounded-2xl bg-neutral-200 transition-transform'}>
+											<div className={'inset-y-0 left-0 h-full rounded-2xl bg-accent-500'} style={{width: `${protocol.tvl ? strategy.tvl / protocol.tvl * 100 : 0}%`}} />
+										</div>
+									</div>
+								</div>
+							</div>
+						);
+					})
+				}
+			</div>
+		);
+	}
+
+	return (
+		<Card.Detail summary={(p: unknown): ReactElement => renderSummary(p as {open: boolean})}>
+			<RenderDetail/>
+		</Card.Detail>
+	);
+});
+
+type		TSectionAllocationsList = {
+	sortBy: string,
+	protocols: TChainData,
+};
+
+const	SectionAllocationsList = React.memo(function SectionAllocationsList({sortBy, protocols}: TSectionAllocationsList): ReactElement {
+	const	[sortedProtocols, set_sortedProtocols] = React.useState([] as TProtocolData[]);
+	React.useEffect((): void => {
+		if(protocols.list){
+			const protocolList = Object.keys(protocols.list).map((protocol): TProtocolData => protocols.list[protocol]);
+			if (['tvl', '-tvl'].includes(sortBy)) {
+				set_sortedProtocols(protocolList.sort((a, b): number => {
+					if (sortBy === '-tvl')
+						return a.tvl - b.tvl;
+					return b.tvl - a.tvl;
+				}));
+			} else if (['name', '-name'].includes(sortBy)) {
+				set_sortedProtocols(protocolList.sort((a, b): number => {
+					const	aName = a.name || '';
+					const	bName = b.name || '';
+					if (sortBy === '-name')
+						return aName.localeCompare(bName);
+					return bName.localeCompare(aName);
+				}));
+			} else if (['strategiesAmount', '-strategiesAmount', ''].includes(sortBy)) {
+				set_sortedProtocols(protocolList.sort((a, b): number => {
+					if (sortBy === '-strategiesAmount')
+						return a.strategiesAmount - b.strategiesAmount;
+					return b.strategiesAmount - a.strategiesAmount;
+				}));
+			} else if (['allocatedStrategiesAmount', '-allocatedStrategiesAmount', ''].includes(sortBy)) {
+				set_sortedProtocols(protocolList.sort((a, b): number => {
+					if (sortBy === '-allocatedStrategiesAmount')
+						return a.allocatedStrategies - b.allocatedStrategies;
+					return b.allocatedStrategies - a.allocatedStrategies;
+				}));
+			}
+		}
+	}, [protocols, sortBy]);
+
+	return (
+		<List className={'flex w-full flex-col space-y-2'}>
+			{sortedProtocols.map((protocol, index): ReactElement => <span key={protocol.name + index}>
+				<ProtocolBox protocol={protocol}/>
+			</span>)}
+		</List>
+	);
+});
+
+export default SectionAllocationsList;

--- a/contexts/useWatch.d.tsx
+++ b/contexts/useWatch.d.tsx
@@ -151,6 +151,12 @@ export type TVault = {
 	strategies: TStrategy[] //From API & subgraph & multicall
 }
 
+export type TVaultByChain = {
+	vaults: TVault[],
+	chainId: number,
+	name: string
+}
+
 export type TGraphStrategies = {
 	address: string,
 	name: string,
@@ -227,9 +233,10 @@ export type	TNetworkData = {
 
 export type	TWatchContext = {
 	vaults: TVault[],
+	dataByChain: TVaultByChain[] | [],
 	lastUpdate: number,
 	isUpdating: boolean,
 	dataChainID: number,
 	network: TNetworkData,
-	update: () => void
+	update: () => void,
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -54,7 +54,7 @@ function	WithLayout(props: AppProps): ReactElement {
 		// 	route: '/risk',
 		// 	values: ['/risk'],
 		// 	label: 'Risk',
-		// 	icon: <IconRisk />
+		// 	icon: <IconHealthcheck />
 		// },
 		{
 			route: '/alerts',
@@ -72,6 +72,12 @@ function	WithLayout(props: AppProps): ReactElement {
 			route: '/track',
 			values: ['/track'],
 			label: 'Track',
+			icon: <IconTrack />
+		},
+		{
+			route: '/allocations',
+			values: ['/allocations'],
+			label: 'Allocations',
 			icon: <IconTrack />
 		},
 		{

--- a/pages/allocations.tsx
+++ b/pages/allocations.tsx
@@ -1,0 +1,202 @@
+import	React, {ReactElement} 		from	'react';
+import	{useWeb3}					from	'@yearn-finance/web-lib/contexts';
+import	SectionAllocationsList		from	'components/sections/allocations/SectionAllocationsList';
+import	{TableHead, TableHeadCell}	from	'components/TableHeadCell';
+import	useWatch					from	'contexts/useWatch';
+import {TRowHead} 					from 	'contexts/useWatch.d';
+
+
+/* 🔵 - Yearn Finance **********************************************************
+** This will render the chain selector for table. This component asks for
+*  sortBy and set_sortBy in order to handle the chevron displays and to set
+** the sort based on the user's choice.
+******************************************************************************/
+function	NetworkSelector({selectedChain, chainList, set_chain}:
+								{
+									selectedChain: string,
+									chainList: string[],
+									set_chain: React.Dispatch<React.SetStateAction<string>>
+								}):
+	ReactElement {
+	return (
+		<div className={'min-w-32 col-span-8 flex flex-row items-center gap-4'}>
+			{chainList?.map((chain, index): ReactElement=>(
+				<div
+					key={index}
+					className={`text-black-600 cursor-pointer rounded-[12px] py-2 px-4 hover:bg-neutral-300${chain === selectedChain ? 'transition-color bg-neutral-300' : 'transition-color bg-neutral-300/50'}`}
+					onClick={(): void=>set_chain(chain)}
+				>
+					{chain}
+				</div>
+			))}
+		</div>
+	);
+}
+
+
+/* 🔵 - Yearn Finance **********************************************************
+** This will render the head of the fake table we have, with the sortable
+** elements. This component asks for sortBy and set_sortBy in order to handle
+** the chevron displays and to set the sort based on the user's choice.
+******************************************************************************/
+function	RowHead({sortBy, set_sortBy}: TRowHead): ReactElement {
+	return (
+		<TableHead sortBy={sortBy} set_sortBy={set_sortBy}>
+			<TableHeadCell
+				className={'cell-start min-w-32 col-span-4'}
+				label={'Protocol'}
+				sortId={'name'} />
+			<TableHeadCell
+				className={'cell-end min-w-36 col-span-5'}
+				label={'Total Value Locked'}
+				sortId={'tvl'} />
+			<TableHeadCell
+				className={'cell-end min-w-36 col-span-5'}
+				label={'Strategies amount'}
+				sortId={'strategiesAmount'} />
+			<TableHeadCell
+				className={'cell-end min-w-36 col-span-6'}
+				label={'Allocated strategies amount'}
+				sortId={'allocatedStrategiesAmount'} />
+		</TableHead>
+	);
+}
+
+export type TProtocolData =  {
+	strategiesTVL: {
+		[strategyName: string]: number
+	},
+	tvl: number,
+	allocatedStrategies: number,
+	name: string,
+	totalDebtRatio: number,
+	strategiesAmount: number
+}
+
+export type TChainData = {
+	tvlTotal: number,
+	protocolsCount?: number,
+	list: {
+		[protocolName: string]: TProtocolData
+	}
+}
+
+export type TProtocolsByChain = {
+	[chainName: string]: TChainData
+}
+
+const initProtocolState = {
+	All: {
+		list: {},
+		tvlTotal: 0
+	}
+};
+
+/* 🔵 - Yearn Finance **********************************************************
+** Main render of the Risk page
+******************************************************************************/
+function	Allocations(): ReactElement {
+	const	{chainID} = useWeb3();
+	const	{dataChainID, dataByChain} = useWatch();
+	const	[sortBy, set_sortBy] = React.useState('tvl');
+	const	[selectedChain, set_chain] = React.useState('All');
+	const	[protocols, set_protocols] = React.useState<TProtocolsByChain>(initProtocolState);
+	/* 🔵 - Yearn Finance ******************************************************
+	** This effect is triggered every time the vault list or the search term is
+	** changed. It filters the vault list based on the search term. This action
+	** takes into account the strategies too.
+	** It also takes into account the router query arguments as additional
+	** filters.
+	**************************************************************************/
+
+
+	React.useEffect((): void => {
+		if (dataChainID !== chainID || dataByChain === []) {
+			set_protocols(initProtocolState);
+			return;
+		}
+		const protocols: TProtocolsByChain = {};
+		protocols.All = {
+			tvlTotal: 0,
+			list: {}
+		};
+		dataByChain.forEach((chainData): void => {
+			protocols[chainData.name] = {
+				tvlTotal: 0,
+				list: {}
+			};
+			chainData.vaults.forEach((vault): void => {
+				vault.strategies.forEach((strategy): void => {
+					if (strategy.protocols) {
+						strategy.protocols.forEach((protocol): void => {
+							if (!protocols[chainData.name].list[protocol]) {
+								protocols[chainData.name].list[protocol] = {
+									strategiesTVL: {},
+									tvl: 0,
+									allocatedStrategies: 0,
+									strategiesAmount: 0,
+									totalDebtRatio: 0,
+									name: protocol
+								};
+							}
+							protocols[chainData.name].list[protocol].tvl += strategy.totalDebtUSDC;
+							if(!protocols[chainData.name].list[protocol].strategiesTVL[strategy.name]){
+								protocols[chainData.name].list[protocol].strategiesTVL[strategy.name] = 0;
+								if(strategy.totalDebtUSDC>0) protocols[chainData.name].list[protocol].allocatedStrategies++;
+							}
+							protocols[chainData.name].list[protocol].strategiesTVL[strategy.name] += strategy.totalDebtUSDC;
+							protocols[chainData.name].tvlTotal += strategy.totalDebtUSDC;
+
+							if (!protocols.All.list[protocol]) {
+								protocols.All.list[protocol] = {
+									strategiesTVL: {},
+									tvl: 0,
+									allocatedStrategies: 0,
+									strategiesAmount: 0,
+									totalDebtRatio: 0,
+									name: protocol
+								};
+							}
+							protocols.All.list[protocol].tvl += strategy.totalDebtUSDC;
+							if(!protocols.All.list[protocol].strategiesTVL[strategy.name]){
+								protocols.All.list[protocol].strategiesTVL[strategy.name] = 0;
+								if(strategy.totalDebtUSDC>0) protocols.All.list[protocol].allocatedStrategies++;
+							}
+							protocols.All.list[protocol].strategiesTVL[strategy.name] += strategy.totalDebtUSDC;
+							protocols.All.tvlTotal += strategy.totalDebtUSDC;
+						});
+					}
+				});
+			});
+			protocols[chainData.name].protocolsCount = Object.keys(protocols[chainData.name].list).length;
+		});
+		Object.keys(protocols).forEach((networkName): void => {
+			if(protocols[networkName].list) {
+				Object.keys(protocols[networkName].list).forEach((protocol): void => {
+					protocols[networkName].list[protocol].strategiesAmount = Object.keys(protocols[networkName].list[protocol].strategiesTVL).length;
+					protocols[networkName].list[protocol].totalDebtRatio =
+						protocols[networkName].list[protocol].tvl /
+						protocols[networkName].tvlTotal * 100;
+				});
+			}
+		});
+		set_protocols(protocols);
+	}, [dataByChain]);
+
+	/* 🔵 - Yearn Finance ******************************************************
+	** Main render of the page.
+	**************************************************************************/
+	return (
+		<div className={'flex-col-full'}>
+			<NetworkSelector selectedChain={selectedChain} chainList={Object.keys(protocols)} set_chain={set_chain}/>
+			<div className={'mt-10 flex h-full overflow-x-scroll pb-0'}>
+				<div className={'flex h-full w-[965px] flex-col md:w-full'}>
+					<RowHead sortBy={sortBy} set_sortBy={set_sortBy} />
+					<SectionAllocationsList sortBy={sortBy} protocols={protocols[selectedChain]} />
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default Allocations;


### PR DESCRIPTION
**Description**

In this PR I have created a page to monitor the amount of allocations for each protocol for certain network or all network combined. On the page you can see a list of protocols with such information as: Protocol name, Total value locked(in $ and %), Strategies amount that have this protocol as allocation point, Strategies amount that have any tokens allocated from this protocol. Also, if you click on any Issue - you will get a list of available strategies, sorted by the tvl, showing which part of Protocol tvl was allocated to this strategy. 

**Related Issue**

https://github.com/yearn/yearn-watch/issues/8